### PR TITLE
GDEV-437 Update reusable-workflow actions to Node 24 (safe bumps)

### DIFF
--- a/.github/actions/coverage/action.yml
+++ b/.github/actions/coverage/action.yml
@@ -20,7 +20,7 @@ inputs:
 runs:
   using: composite
   steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
       with:
         ref: ${{ inputs.ref }}
     - id: setup

--- a/.github/actions/setup-java/action.yml
+++ b/.github/actions/setup-java/action.yml
@@ -26,12 +26,12 @@ inputs:
 runs:
   using: composite
   steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
       with:
         ref: ${{ inputs.ref }}
 
     # Standard Java (Temurin, Corretto, etc.)
-    - uses: actions/setup-java@v4
+    - uses: actions/setup-java@v5
       if: ${{ inputs.distribution != 'graalvm' }}
       with:
         distribution: ${{ inputs.distribution }}
@@ -46,7 +46,7 @@ runs:
         github-token: ${{ github.token }}
 
     # Maven cache and settings (shared by both)
-    - uses: actions/cache@v4
+    - uses: actions/cache@v5
       with:
         path: ~/.m2
         key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}

--- a/.github/actions/sonar-scan/action.yml
+++ b/.github/actions/sonar-scan/action.yml
@@ -47,7 +47,7 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
       with:
         ref: ${{ inputs.stage == 'stg' && github.event.workflow_run.head_branch || '' }}
     - id: setup
@@ -92,7 +92,7 @@ runs:
       with:
         python-version: ${{ fromJson(steps.setup.outputs.sonar).python.version }}
     - if: ${{ steps.setup.outputs.javascript == 'true' }}
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@v6
       with:
         node-version: ${{ fromJson(steps.setup.outputs.sonar).javascript.version }}
     - id: python-coverage

--- a/.github/actions/veracode-scan/action.yml
+++ b/.github/actions/veracode-scan/action.yml
@@ -51,7 +51,7 @@ runs:
       run: |
         echo "continue=${{ (github.event.workflow_run && github.event.workflow_run.conclusion == 'success') || (!github.event.workflow_run) }}" >> $GITHUB_OUTPUT
     - if: ${{ steps.execution.outputs.continue == 'true' }}
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
       with:
         ref: ${{ inputs.stage == 'stg' && github.event.workflow_run.head_branch || '' }}
     - if: ${{ steps.execution.outputs.continue == 'true' }}
@@ -86,11 +86,11 @@ runs:
         version: ${{ fromJson(steps.setup.outputs.veracode).java.java-version || env.DEFAULT_JAVA_VERSION }}
         ref: ${{ inputs.stage == 'stg' && github.event.workflow_run.head_branch || '' }}
     - if: ${{ steps.execution.outputs.continue == 'true' && steps.setup.outputs.react == 'true' }}
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@v6
       with:
         node-version: ${{ fromJson(steps.setup.outputs.veracode).react.node-version || env.DEFAULT_NODE_VERSION }}
     - if: ${{ steps.execution.outputs.continue == 'true' && steps.setup.outputs.angular == 'true' }}
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@v6
       with:
         node-version: ${{ fromJson(steps.setup.outputs.veracode).angular.node-version || env.DEFAULT_NODE_VERSION }}
     - if: ${{ steps.execution.outputs.continue == 'true' }}

--- a/.github/workflows/build-deploy-react-angular.yml
+++ b/.github/workflows/build-deploy-react-angular.yml
@@ -107,7 +107,7 @@ jobs:
     # END CONFIGURATION
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Parse Jira Keys from Commit
         id: jira_keys
         if: always()
@@ -125,7 +125,7 @@ jobs:
       - name: Echo Jira Keys
         run: |
           echo "Jira Keys: ${{env.JIRA_KEYS}}"
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: ${{ env.NODE_VERSION }}
       - name: Install Dependencies

--- a/.github/workflows/graalvm-maven-build.yml
+++ b/.github/workflows/graalvm-maven-build.yml
@@ -28,14 +28,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Set up JDK ${{ env.JAVA_VERSION }}
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with: 
           distribution: 'temurin'
           java-version: '${{ env.JAVA_VERSION }}'
       - name: Cache Maven
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/.m2
           key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}

--- a/.github/workflows/graphql-build-docs.yml
+++ b/.github/workflows/graphql-build-docs.yml
@@ -30,7 +30,7 @@ jobs:
       image: gravicore/alpine-node-aws-chamber:latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Install graphdoc
         run: npm install -g @2fd/graphdoc
       - name: Run graphdoc

--- a/.github/workflows/lambda-layers-java.yml
+++ b/.github/workflows/lambda-layers-java.yml
@@ -23,14 +23,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Set up JDK ${{ inputs.JAVA_VERSION }}
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           distribution: 'temurin'
           java-version: ${{ inputs.JAVA_VERSION }}
       - name: Cache Maven
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/.m2
           key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}

--- a/.github/workflows/maven-build.yml
+++ b/.github/workflows/maven-build.yml
@@ -24,14 +24,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Set up JDK ${{ env.JAVA_VERSION }}
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with: 
           distribution: 'temurin'
           java-version: '${{ env.JAVA_VERSION }}'
       - name: Cache Maven
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/.m2
           key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}

--- a/.github/workflows/terragrunt-build-deploy.yml
+++ b/.github/workflows/terragrunt-build-deploy.yml
@@ -88,7 +88,7 @@ jobs:
     runs-on: ${{ inputs.RUNNER }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Setup Terraform
         uses: hashicorp/setup-terraform@v3
         with:
@@ -130,7 +130,7 @@ jobs:
     runs-on: ${{ inputs.RUNNER }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Parse Jira Keys from Commit
         id: jira_keys
         if: ${{ (inputs.JIRA_ID_FROM_BRANCH == false) }}
@@ -257,7 +257,7 @@ jobs:
     runs-on: ${{ inputs.RUNNER }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - uses: actions/setup-python@v5
         with:
           python-version: "3.10"

--- a/.github/workflows/terragrunt-deploy-assign.yml
+++ b/.github/workflows/terragrunt-deploy-assign.yml
@@ -74,7 +74,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
       - name: Setup Terraform
         uses: hashicorp/setup-terraform@v3
         with:
@@ -120,9 +120,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
       - name: Setup Node.js
-        uses: actions/setup-node@v5
+        uses: actions/setup-node@v6
         with:
           node-version: '${{ env.NODE_VERSION }}'
       - name: Verify Node.js installation
@@ -257,9 +257,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
       - name: Setup Node.js
-        uses: actions/setup-node@v5
+        uses: actions/setup-node@v6
         with:
           node-version: '${{ env.NODE_VERSION }}'
       - name: Verify Node.js installation

--- a/.github/workflows/tg-build-deploy-ignore-path.yml
+++ b/.github/workflows/tg-build-deploy-ignore-path.yml
@@ -83,7 +83,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Setup Terraform
         uses: hashicorp/setup-terraform@v3
         with:
@@ -126,7 +126,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - uses: dorny/paths-filter@v3
         if: "github.ref != 'refs/heads/main'"
         id: filter
@@ -228,7 +228,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - uses: dorny/paths-filter@v3
         if: "github.ref != 'refs/heads/main'"
         id: filter

--- a/.github/workflows/veracode-policy-sast.yml
+++ b/.github/workflows/veracode-policy-sast.yml
@@ -75,7 +75,7 @@ jobs:
     if: inputs.PYTHON_INCLUDE == true
     steps:
       - name: checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: create folder dist
         run: mkdir dist
       - name: install zip
@@ -93,7 +93,7 @@ jobs:
       - name: Gather time stamp
         run:  echo "CURRENT_TIME=$(date +"%y%m%d%H%M%S")" >> $GITHUB_ENV
       - name: Setup Java
-        uses: actions/setup-java@v4 # Make java accessible on path so the uploadandscan action can run.
+        uses: actions/setup-java@v5 # Make java accessible on path so the uploadandscan action can run.
         with: 
           distribution: 'temurin'
           java-version: ${{ inputs.JAVA_VERSION }}
@@ -114,14 +114,14 @@ jobs:
     if: inputs.JAVA_INCLUDE == true
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Set up JDK '${{ inputs.JAVA_VERSION }}'
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           distribution: 'temurin'
           java-version: '${{ inputs.JAVA_VERSION }}'
       - name: Cache Maven
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/.m2
           key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
@@ -136,7 +136,7 @@ jobs:
       - name: Branch Name Var
         run: echo "BRANCH_NAME=${GITHUB_HEAD_REF}"  >> $GITHUB_ENV
       - name: Setup Java
-        uses: actions/setup-java@v4 # Make java accessible on path so the uploadandscan action can run.
+        uses: actions/setup-java@v5 # Make java accessible on path so the uploadandscan action can run.
         with: 
           distribution: 'temurin'
           java-version: ${{ inputs.JAVA_VERSION }}
@@ -157,8 +157,8 @@ jobs:
     if: inputs.REACT_ANGULAR_INCLUDE == true
     steps:    
       - name: Checkout
-        uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+        uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
         with:
           node-version: ${{inputs.NODE_VERSION}}
       - name: Install Dependencies
@@ -190,7 +190,7 @@ jobs:
     container: mcr.microsoft.com/dotnet/sdk:3.1-alpine
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: "Build"
         run: |
           apk add p7zip
@@ -201,7 +201,7 @@ jobs:
       - name: Gather time stamp
         run:  echo "CURRENT_TIME=$(date +"%y%m%d%H%M%S")" >> $GITHUB_ENV
       - name: Setup Java
-        uses: actions/setup-java@v4 # Make java accessible on path so the uploadandscan action can run.
+        uses: actions/setup-java@v5 # Make java accessible on path so the uploadandscan action can run.
         with: 
           distribution: 'temurin'
           java-version: ${{ inputs.JAVA_VERSION }}

--- a/.github/workflows/veracode-sast.yml
+++ b/.github/workflows/veracode-sast.yml
@@ -76,12 +76,12 @@ jobs:
     steps:
       - name: Checkout Stg
         if: ${{ ( env.DEPLOYMENT_STAGE == 'stg') }}
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: ${{ github.event.workflow_run.head_branch }}
       - name: Checkout Prd
         if: ${{ ( env.DEPLOYMENT_STAGE == 'prd') }}
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: create folder dist
         run: mkdir dist
       - name: install zip
@@ -99,7 +99,7 @@ jobs:
       - name: Gather time stamp
         run:  echo "CURRENT_TIME=$(date +"%y%m%d%H%M%S")" >> $GITHUB_ENV
       - name: Setup Java
-        uses: actions/setup-java@v4 # Make java accessible on path so the uploadandscan action can run.
+        uses: actions/setup-java@v5 # Make java accessible on path so the uploadandscan action can run.
         with: 
           distribution: 'temurin'
           java-version: '${{ inputs.JAVA_VERSION }}'
@@ -134,19 +134,19 @@ jobs:
     steps:
       - name: Checkout Stg
         if: ${{ ( env.DEPLOYMENT_STAGE == 'stg') }}
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: ${{ github.event.workflow_run.head_branch }}
       - name: Checkout Prd
         if: ${{ ( env.DEPLOYMENT_STAGE == 'prd') }}      
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Set up JDK '${{ inputs.JAVA_VERSION }}'
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           distribution: 'temurin'
           java-version: '${{ inputs.JAVA_VERSION }}'
       - name: Cache Maven
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/.m2
           key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
@@ -191,13 +191,13 @@ jobs:
     steps:    
       - name: Checkout Stg
         if: ${{ ( env.DEPLOYMENT_STAGE == 'stg') }}
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: ${{ github.event.workflow_run.head_branch }}
       - name: Checkout Prd
         if: ${{ ( env.DEPLOYMENT_STAGE == 'prd') }}
-        uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+        uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
         with:
           node-version: ${{inputs.NODE_VERSION}}
       - name: Install Dependencies
@@ -243,12 +243,12 @@ jobs:
     steps:
       - name: Checkout Stg
         if: ${{ ( env.DEPLOYMENT_STAGE == 'stg') }}
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: ${{ github.event.workflow_run.head_branch }}
       - name: Checkout Prd
         if: ${{ ( env.DEPLOYMENT_STAGE == 'prd') }}      
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: "Build"
         run: |
           apk add p7zip
@@ -259,7 +259,7 @@ jobs:
       - name: Gather time stamp
         run:  echo "CURRENT_TIME=$(date +"%y%m%d%H%M%S")" >> $GITHUB_ENV
       - name: Setup Java
-        uses: actions/setup-java@v4 # Make java accessible on path so the uploadandscan action can run.
+        uses: actions/setup-java@v5 # Make java accessible on path so the uploadandscan action can run.
         with: 
           distribution: 'temurin'
           java-version: '${{ inputs.JAVA_VERSION }}'

--- a/.github/workflows/versioning-upload.yml
+++ b/.github/workflows/versioning-upload.yml
@@ -66,7 +66,7 @@ jobs:
     runs-on: ubuntu-latest
     name: Bump Version
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Bump version and push tag
         id: tag_version
         uses: mathieudutour/github-tag-action@v6.2
@@ -97,7 +97,7 @@ jobs:
     container: gravicore/alpine-node-aws-chamber
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Download Project Artifacts
         uses: actions/download-artifact@v4
         with:
@@ -168,8 +168,8 @@ jobs:
       - name: Variablize version tag
         run: cat version_tag.txt >> $GITHUB_ENV
       - name: Checkout
-        uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+        uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
         with:
           node-version: ${{ env.NODE_VERSION }}
       - name: Install Dependencies


### PR DESCRIPTION
## What
Move the Node 20-era GitHub Actions in this repo onto their Node 24 majors, repo-wide, limited to the safe in-family bumps.

**Bumped everywhere (composites + workflows):**
- `actions/checkout` `@v4`/`@v5` → `@v6`
- `actions/setup-node` `@v4`/`@v5` → `@v6`
- `actions/setup-java` `@v4` → `@v5`
- `actions/cache` `@v4` → `@v5`

All targets verified as `runs.using: node24`. Version-only changes — no logic changes.

## Why
GitHub is deprecating Node 20 on runners. These surfaced as Node 20 deprecation warnings across builds using this repo's actions/workflows — including the `setup-java` composite behind the `cel-srv-services-dcc` **Compile Maven Project** jobs.

## Deliberately out of scope
These are also Node 20 but are **not** safe in-family bumps, so they're left for a separate, tested effort:
- `actions/upload-artifact@v4` → v6/v7 and `actions/download-artifact@v4` → v7/v8 — multi-major jumps with breaking changes (hash-mismatch enforcement, ESM, artifact immutability); upload/download must move in lockstep and be tested since workflows pass artifacts between jobs.
- `actions/setup-python@v5`, `actions/setup-dotnet@v4` — single-use; would need the same major-bump verification.

So this PR clears most, but not all, Node 20 warnings in the repo.

## Blast radius
These actions/composites feed builds across the org, so this applies to all consumers on merge — worth a sanity check on one consumer build (e.g. a DCC run) afterward.

Ticket: GDEV-437
🤖 Generated with [Claude Code](https://claude.com/claude-code)
